### PR TITLE
Fix icons being included twice in sprite

### DIFF
--- a/src/scss/_functions.scss
+++ b/src/scss/_functions.scss
@@ -23,7 +23,7 @@
 @function _oShareGetSpriteUrl() {
 	$url: "//image.webservices.ft.com/v1/images/raw/";
 
-	@each $social, $number in $_o-share-sprite-elements {
+	@each $social in $_o-share-sprite-elements {
 		$url: $url + "ftsocial:" + $social + ",";
 	}
 


### PR DESCRIPTION
Probably only happening with libsass - but $_o-share-sprite-elements is an array, not a map

/cc @kaelig @AlbertoElias 