### PR TITLE
Fix the double popup when Twitter intents is loaded on the page.

### DIFF
--- a/src/js/share.js
+++ b/src/js/share.js
@@ -51,6 +51,8 @@ function Share(rootEl, config) {
 
 		if (oShare.rootEl.contains(actionEl) && actionEl.querySelector('a[href]')) {
 			ev.preventDefault();
+			ev.stopPropagation();
+
 			const url = actionEl.querySelector('a[href]').href;
 
 			dispatchCustomEvent('event', {


### PR DESCRIPTION
Twitter intents (https://dev.twitter.com/web/intents) parses the page for twitter links, and adds event handlers for showing a popup. o-share does the same, the result being 2 popups open (with any twitter widget on the page).

This is the case on AV2 as well, where we have a twitter widget in the right hand rail (https://ftalphaville2-test.ft.com/content/7b4b3d5d-514c-334d-b5f3-8bd8e24d349e). Preventing the propagation of the events on the link fixes the issue.