### PR TITLE
Fix sizing issue and high contrast usage

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,8 @@
   "dependencies": {
     "ftdomdelegate": "^2.0.0",
     "o-colors": "^3.6.0",
-    "o-normalise": "^1.2.0"
+    "o-normalise": "^1.2.0",
+    "o-grid": "^4.3.1"
   },
   "main": [
     "main.scss",

--- a/main.scss
+++ b/main.scss
@@ -1,4 +1,5 @@
 @import 'o-colors/main';
+@import 'o-grid/main';
 @import 'o-normalise/main';
 
 @import 'src/scss/variables';

--- a/src/scss/share.scss
+++ b/src/scss/share.scss
@@ -153,6 +153,21 @@
 		}
 	}
 
+	// Targets displays using any of Windows’ High Contrast Mode themes:
+	// target all high-contrast themes and force a white icon with black background
+	@media screen and (-ms-high-contrast: active) {
+		$hover-color: oColorsGetColorFor('o-share-button-inverse', background);
+
+		$hover-color: str-slice(ie-hex-str($hover-color), 4);
+		$tint: "&tint=%23#{$hover-color},%23#{$hover-color}";
+
+		.#{$classname}__action--#{$icon-name} i {
+			background-color: oColorsGetPaletteColor('black');
+			background-image: url($service-url + $query + "&format=svg#{$tint}");
+			background-image: url($service-url + $query + "&format=png#{$tint}&width=#{$o-share-icon-size}")\9;
+		}
+	}
+
 	.#{$classname}__action--#{$icon-name}:hover,
 	.#{$classname}__action--#{$icon-name}:focus {
 		border-color: oColorsGetColorFor('o-share-#{$icon-name}-color', background);
@@ -201,6 +216,11 @@
 				i {
 					background-image: url($service-url + $query + "&format=svg#{$tint}");
 					background-image: url($service-url + $query + "&format=png#{$tint}&width=#{$o-share-icon-size}")\9;
+
+					// Force the background to be black in high-contrast mode
+					@media screen and (-ms-high-contrast: active) {
+						background-color: oColorsGetPaletteColor('black');
+					}
 				}
 			}
 		}

--- a/src/scss/share.scss
+++ b/src/scss/share.scss
@@ -16,7 +16,10 @@
 	}
 
 	.#{$classname}__action {
+		box-sizing: border-box;
 		float: left;
+		width: $o-share-icon-size;
+		height: $o-share-icon-size;
 		margin: 0 5px 0 0;
 		list-style-type: none;
 		line-height: $o-share-icon-size;
@@ -37,7 +40,15 @@
 			display: block;
 			width: $o-share-icon-size;
 			text-decoration: none;
+			border: 0;
 			overflow: hidden;
+		}
+
+		button {
+			display: block;
+			border: 0;
+			padding: 0;
+			background-color: transparent;
 		}
 
 		&:first-child a {

--- a/src/scss/share.scss
+++ b/src/scss/share.scss
@@ -27,6 +27,10 @@
 		border-radius: $o-normalise-border-radius;
 		cursor: pointer;
 
+		@include oGridRespondTo(S) {
+			margin-right: 10px;
+		}
+
 		i {
 			float: left;
 			background-size: 100% 100%;
@@ -37,11 +41,29 @@
 		}
 
 		a {
+			position: relative;
 			display: block;
 			width: $o-share-icon-size;
 			text-decoration: none;
 			border: 0;
-			overflow: hidden;
+
+			// Increase the hit target to improve a11y
+			&:after {
+				position: absolute;
+				display: block;
+				content: '';
+				width: $o-share-icon-size + 5;
+				height: $o-share-icon-size + 5;
+				top: -2px;
+				left: -2px;
+
+				@include oGridRespondTo(S) {
+					width: $o-share-icon-size + 10px;
+					height: $o-share-icon-size + 10px;
+					top: -5px;
+					left: -5px;
+				}
+			}
 		}
 
 		button {


### PR DESCRIPTION
Button size is now at `40px` square including borders and has a hit area of `45px` at default, increasing to `50px` from small up.

Also fixes an issue with black icons not appearing in Windows high-contrast mode. Sets icon to white and forces a black background which is not changed when Windows is using any high-contrast theme. Tested in both Windows and Mac high-contrast modes thanks to @lc512k 

Closes #59 