### PR TITLE
Patch for v3 - Do not pass the opener window object to the new page

### DIFF
--- a/src/js/share.js
+++ b/src/js/share.js
@@ -117,6 +117,7 @@ function Share(rootEl, config) {
 				openWindows[url].focus();
 			} else {
 				openWindows[url] = window.open(url, '', 'width=646,height=436');
+				openWindows[url].opener = null;
 			}
 
 			dispatchCustomEvent('open', {


### PR DESCRIPTION
Passing the window object of the page which opened the social sharing site makes us susceptible to phishing and XSS attacks.

E.G. Code the social sharing sites could use to attack us.
```js
// window.opener would be the window object of the page the user clicked the sharing button on, probably an ft article.
if (window.opener) {
  window.opener.location = 'https://www.ft.com.example.com' // Fake FT login page to steal users credentials
}
```