### PR TITLE
remove superfluous params

### DIFF
--- a/demos/src/inverse.mustache
+++ b/demos/src/inverse.mustache
@@ -8,7 +8,7 @@
 			{{/o-share.withTwitter}}
 			{{#o-share.withFacebook}}
 			<li class="o-share__action">
-				<a class="o-share__icon o-share__icon--facebook" href="http://www.facebook.com/sharer.php?u={{o-share.url}}&amp;t={{o-share.title}}+|+{{o-share.titleExtra}}" rel="noopener"><span class="o-share__text">Facebook</span></a>
+				<a class="o-share__icon o-share__icon--facebook" href="http://www.facebook.com/sharer.php?u={{o-share.url}}" rel="noopener"><span class="o-share__text">Facebook</span></a>
 			</li>
 			{{/o-share.withFacebook}}
 			{{#o-share.withLinkedin}}

--- a/demos/src/pa11y.mustache
+++ b/demos/src/pa11y.mustache
@@ -89,7 +89,7 @@
 			{{/o-share.withTwitter}}
 			{{#o-share.withFacebook}}
 			<li class="o-share__action">
-				<a class="o-share__icon o-share__icon--facebook" href="http://www.facebook.com/sharer.php?u={{o-share.url}}&amp;t={{o-share.title}}+|+{{o-share.titleExtra}}" rel="noopener"><span class="o-share__text">Facebook</span></a>
+				<a class="o-share__icon o-share__icon--facebook" href="http://www.facebook.com/sharer.php?u={{o-share.url}}" rel="noopener"><span class="o-share__text">Facebook</span></a>
 			</li>
 			{{/o-share.withFacebook}}
 			{{#o-share.withLinkedin}}

--- a/src/js/share.js
+++ b/src/js/share.js
@@ -4,7 +4,7 @@ const DomDelegate = require('ftdomdelegate');
 
 const socialUrls = {
 	twitter: "https://twitter.com/intent/tweet?url={{url}}&text={{title}}&related={{relatedTwitterAccounts}}&via=FT",
-	facebook: "http://www.facebook.com/sharer.php?u={{url}}&t={{title}}+%7C+{{titleExtra}}",
+	facebook: "http://www.facebook.com/sharer.php?u={{url}}",
 	linkedin: "http://www.linkedin.com/shareArticle?mini=true&url={{url}}&title={{title}}+%7C+{{titleExtra}}&summary={{summary}}&source=Financial+Times",
 	googleplus: "https://plus.google.com/share?url={{url}}",
 	pinterest: "http://www.pinterest.com/pin/create/button/?url={{url}}&description={{title}}",


### PR DESCRIPTION
This is just removing bits that facebook won't recognise anymore, but it seems like @jkerr321 already updated the docs in https://github.com/Financial-Times/o-share/commit/d6a60727935efcd288aefe7e41660655dbd285b3.

Closes #98 