### PR TITLE
Re-add the link icon

### DIFF
--- a/demos/src/inverse.mustache
+++ b/demos/src/inverse.mustache
@@ -36,6 +36,11 @@
 				<button class="o-share__icon o-share__icon--mail"><span class="o-share__text">Mail</span></button>
 			</li>
 			{{/o-share.withMail}}
+			{{#o-share.withLink}}
+			<li class="o-share__action">
+				<a href="{{{o-share.url}}}" class="o-share__icon o-share__icon--link"><span class="o-share__text">URL</span></a>
+			</li>
+			{{/o-share.withLink}}
 		</ul>
 	</div>
 </div>

--- a/demos/src/main.mustache
+++ b/demos/src/main.mustache
@@ -36,6 +36,11 @@
 				<button class="o-share__icon o-share__icon--mail"><span class="o-share__text">Mail</span></button>
 			</li>
 			{{/o-share.withMail}}
+			{{#o-share.withLink}}
+			<li class="o-share__action">
+				<a href="{{{o-share.url}}}" class="o-share__icon o-share__icon--link"><span class="o-share__text">URL</span></a>
+			</li>
+			{{/o-share.withLink}}
 		</ul>
 	</div>
 </div>

--- a/src/scss/_color-use-cases.scss
+++ b/src/scss/_color-use-cases.scss
@@ -2,6 +2,7 @@
 @include oColorsSetUseCase(tooltip, background, 'black-80');
 
 @include oColorsSetUseCase('o-share-mail-color', background, 'teal-40');
+@include oColorsSetUseCase('o-share-link-color', background, 'teal-40');
 
 @include oColorsSetUseCase('o-share-button-default', border, 'black');
 @include oColorsSetUseCase('o-share-button-hover', background, 'white');

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -26,7 +26,7 @@ $o-share-ft-icons-version: "1" !default;
 
 /// List of accepted social network icons, and the version
 /// @type map
-$_o-share-icons: (twitter, facebook, googleplus, linkedin, mail, pinterest, whatsapp);
+$_o-share-icons: (twitter, facebook, googleplus, linkedin, link, mail, pinterest, whatsapp);
 
 $o-share-colors: (
 	twitter: #1da1f2,

--- a/src/scss/share.scss
+++ b/src/scss/share.scss
@@ -53,7 +53,7 @@
 	// sass-lint:disable-all
 	$scheme: "ftsocial-v#{$o-share-social-icons-version}";
 
-	@if ($icon-name == 'mail') {
+	@if ($icon-name == 'mail' or $icon-name == 'link') {
 		$scheme: "fticon-v#{$o-share-ft-icons-version}";
 	}
 
@@ -158,10 +158,11 @@
 		}
 
 		@each $icon-name in $_o-share-icons {
+
 			// sass-lint:disable-all
 			$scheme: "ftsocial-v#{$o-share-social-icons-version}";
 
-			@if ($icon-name == 'mail') {
+			@if ($icon-name == 'mail' or $icon-name == 'link') {
 				$scheme: "fticon-v#{$o-share-ft-icons-version}";
 			}
 


### PR DESCRIPTION
This doesn't need the full "copy a URL" functionality, but it's used to
link to video pages on the FT.com home page and its disappearance is
holding up their work.

Resolves #111