### PR TITLE
Support "share" icon as well as "mail" & "link"

### DIFF
--- a/demos/src/data-vertical.json
+++ b/demos/src/data-vertical.json
@@ -13,6 +13,7 @@
         "withMail": true,
         "withPinterest": true,
         "withLink": true,
+        "withShare": true,
         "isVertical": true
     }
 }

--- a/demos/src/data.json
+++ b/demos/src/data.json
@@ -12,6 +12,7 @@
     	"withGoogleplus": true,
     	"withPinterest": true,
     	"withLink": true,
-    	"withMail": true
+    	"withMail": true,
+        "withShare": true
     }
 }

--- a/demos/src/demo.scss
+++ b/demos/src/demo.scss
@@ -5,7 +5,7 @@ $o-share-is-silent: false;
 	// sass-lint:disable-all
 	$scheme: "ftsocial-v#{$o-share-social-icons-version}";
 
-	@if ($icon-name == 'mail' or $icon-name == 'link') {
+	@if (index($o-share-ft-icons-names, $icon-name)) {
 		$scheme: "fticon-v#{$o-share-ft-icons-version}";
 	}
 

--- a/demos/src/inverse.mustache
+++ b/demos/src/inverse.mustache
@@ -41,6 +41,11 @@
 				<a href="{{{o-share.url}}}" class="o-share__icon o-share__icon--link"><span class="o-share__text">URL</span></a>
 			</li>
 			{{/o-share.withLink}}
+			{{#o-share.withShare}}
+				<li class="o-share__action">
+					<a href="{{{o-share.url}}}" class="o-share__icon o-share__icon--share"><span class="o-share__text">Share</span></a>
+				</li>
+			{{/o-share.withShare}}
 		</ul>
 	</div>
 </div>

--- a/demos/src/main.mustache
+++ b/demos/src/main.mustache
@@ -41,6 +41,11 @@
 				<a href="{{{o-share.url}}}" class="o-share__icon o-share__icon--link"><span class="o-share__text">URL</span></a>
 			</li>
 			{{/o-share.withLink}}
+			{{#o-share.withShare}}
+			<li class="o-share__action">
+				<a href="{{{o-share.url}}}" class="o-share__icon o-share__icon--share"><span class="o-share__text">Share</span></a>
+			</li>
+			{{/o-share.withShare}}
 		</ul>
 	</div>
 </div>

--- a/demos/src/pa11y.mustache
+++ b/demos/src/pa11y.mustache
@@ -36,6 +36,11 @@
 				<button class="o-share__icon o-share__icon--mail"><span class="o-share__text">Mail</span></button>
 			</li>
 			{{/o-share.withMail}}
+			{{#o-share.withShare}}
+				<li class="o-share__action">
+					<a href="{{{o-share.url}}}" class="o-share__icon o-share__icon--share"><span class="o-share__text">Share</span></a>
+				</li>
+			{{/o-share.withShare}}
 		</ul>
 	</div>
 
@@ -76,6 +81,11 @@
 				<button class="o-share__icon o-share__icon--mail demo-hover"><span class="o-share__text">Mail</span></button>
 			</li>
 			{{/o-share.withMail}}
+			{{#o-share.withShare}}
+				<li class="o-share__action">
+					<button class="o-share__icon o-share__icon--share demo-hover"><span class="o-share__text">Share</span></button>
+				</li>
+			{{/o-share.withShare}}
 		</ul>
 	</div>
 </div>
@@ -117,6 +127,11 @@
 				<button class="o-share__icon o-share__icon--mail"><span class="o-share__text">Mail</span></button>
 			</li>
 			{{/o-share.withMail}}
+			{{#o-share.withShare}}
+				<li class="o-share__action">
+					<button class="o-share__icon o-share__icon--share"><span class="o-share__text">Share</span></button>
+				</li>
+			{{/o-share.withShare}}
 		</ul>
 	</div>
 </div>

--- a/src/scss/_color-use-cases.scss
+++ b/src/scss/_color-use-cases.scss
@@ -3,6 +3,7 @@
 
 @include oColorsSetUseCase('o-share-mail-color', background, 'teal-40');
 @include oColorsSetUseCase('o-share-link-color', background, 'teal-40');
+@include oColorsSetUseCase('o-share-share-color', background, 'teal-40');
 
 @include oColorsSetUseCase('o-share-button-default', border, 'black');
 @include oColorsSetUseCase('o-share-button-hover', background, 'white');

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -24,9 +24,13 @@ $o-share-image-service-version: "v2" !default;
 $o-share-social-icons-version: "2" !default;
 $o-share-ft-icons-version: "1" !default;
 
+// Icon names that will use fticons instead of ftsocial
+/// @type map
+$o-share-ft-icons-names: (mail link share);
+
 /// List of accepted social network icons, and the version
 /// @type map
-$_o-share-icons: (twitter, facebook, googleplus, linkedin, link, mail, pinterest, whatsapp);
+$_o-share-icons: (twitter, facebook, googleplus, linkedin, link, share, mail, pinterest, whatsapp);
 
 $o-share-colors: (
 	twitter: #1da1f2,

--- a/src/scss/share.scss
+++ b/src/scss/share.scss
@@ -53,7 +53,7 @@
 	// sass-lint:disable-all
 	$scheme: "ftsocial-v#{$o-share-social-icons-version}";
 
-	@if ($icon-name == 'mail' or $icon-name == 'link') {
+	@if (index($o-share-ft-icons-names, $icon-name)) {
 		$scheme: "fticon-v#{$o-share-ft-icons-version}";
 	}
 
@@ -155,7 +155,7 @@
 			// sass-lint:disable-all
 			$scheme: "ftsocial-v#{$o-share-social-icons-version}";
 
-			@if ($icon-name == 'mail' or $icon-name == 'link') {
+			@if (index($o-share-ft-icons-names, $icon-name)) {
 				$scheme: "fticon-v#{$o-share-ft-icons-version}";
 			}
 


### PR DESCRIPTION
In next-article, we want to use the share icon instead of the link icon.

The changes in this PR are what I think is necessary to support this.