### PR TITLE
Darken social share border to improve contrast.

### DIFF
--- a/src/scss/_color-use-cases.scss
+++ b/src/scss/_color-use-cases.scss
@@ -5,7 +5,7 @@
 @include oColorsSetUseCase('o-share-link-color', background, 'teal-40');
 @include oColorsSetUseCase('o-share-share-color', background, 'teal-40');
 
-@include oColorsSetUseCase('o-share-button-default', border, 'black');
+@include oColorsSetUseCase('o-share-button-default', border, 'black-50');
 @include oColorsSetUseCase('o-share-button-hover', background, 'white');
 
 @include oColorsSetUseCase('o-share-button-inverse', border, 'white');

--- a/src/scss/share.scss
+++ b/src/scss/share.scss
@@ -22,7 +22,7 @@
 		margin: 0 5px 0 0;
 		list-style-type: none;
 		line-height: $o-share-icon-size;
-		border: 1px solid rgba(oColorsGetColorFor('o-share-button-default', 'border'), 0.2);
+		border: 1px solid oColorsGetColorFor('o-share-button-default', 'border');
 		border-radius: $o-normalise-border-radius;
 		cursor: pointer;
 
@@ -103,12 +103,12 @@
 		width: #{$o-share-icon-size};
 		height: #{$o-share-icon-size};
 		background-image: url($service-url + $query + "&format=svg");
-		
+
 		// Hack to load icon early to prevent FOIC on hover
 		&:after {
 			content: '';
 			background-image: url($service-url + $query + "&format=svg#{$tint}");
-		}	
+		}
 	}
 
 	// Targets displays using any of Windows’ High Contrast Mode themes:


### PR DESCRIPTION
In response to our [DAC Accessibility Audit Report](https://docs.google.com/spreadsheets/d/1_Wp100e-2gwGQDxPS6YODqFsVRwycO9Y6PiXzppU-TY/edit#gid=2122682530).

before / after
<img width="140" alt="Screenshot 2019-05-20 at 10 36 11" src="https://user-images.githubusercontent.com/10405691/58012275-0c600280-7aec-11e9-997b-7b6eb53e8251.png">
