### PR TITLE
add a new action class at the list element level

### DIFF
--- a/src/js/share.js
+++ b/src/js/share.js
@@ -139,7 +139,7 @@ function Share(rootEl, config) {
 			const spanElement = document.createElement('span');
 			const aElement = document.createElement('a');
 
-			liElement.classList.add('o-share__action');
+			liElement.classList.add('o-share__action', `o-share__action--${config.links[i]}`);
 			spanElement.classList.add('o-share__text');
 			aElement.classList.add('o-share__icon', `o-share__icon--${config.links[i]}`);
 			aElement.href = generateSocialUrl(config.links[i]);


### PR DESCRIPTION
To support show/hide functionality at the list-item level. 

The whatsapp share icon should only be visible on smaller viewports. This change allows us to target the element at the list-item level and to have the show/hide behaviour persist when user-navigation causes the share icons to be refreshed. 