### PR TITLE
add link to the list of valid socialUrls

### DIFF
--- a/src/js/share.js
+++ b/src/js/share.js
@@ -6,7 +6,8 @@ const socialUrls = {
 	linkedin: "http://www.linkedin.com/shareArticle?mini=true&url={{url}}&title={{title}}+%7C+{{titleExtra}}&summary={{summary}}&source=Financial+Times",
 	googleplus: "https://plus.google.com/share?url={{url}}",
 	pinterest: "http://www.pinterest.com/pin/create/button/?url={{url}}&description={{title}}",
-	whatsapp: "whatsapp://send?text={{title}}%20({{titleExtra}})%20-%20{{url}}"
+	whatsapp: "whatsapp://send?text={{title}}%20({{titleExtra}})%20-%20{{url}}",
+	link: "{{url}}"
 };
 
 /**


### PR DESCRIPTION
To support a refactor of the share links into a single list in the video section of the front page.

Adding 'link' as a sociallUrl allows us to treat all video share links consistently. This simplifies the share icons code and ensures greater visual consistency between the icons. 

