### PR TITLE
Adds encoding to the url before sharing

### DIFF
--- a/src/js/share.js
+++ b/src/js/share.js
@@ -116,7 +116,7 @@ function Share(rootEl, config) {
 	  */
 	function generateSocialUrl(socialNetwork) {
 		let templateUrl = socialUrls[socialNetwork];
-		templateUrl = templateUrl.replace('{{url}}', config.url)
+		templateUrl = templateUrl.replace('{{url}}', encodeURIComponent(config.url))
 			.replace('{{title}}', encodeURIComponent(config.title))
 			.replace('{{titleExtra}}', encodeURIComponent(config.titleExtra))
 			.replace('{{summary}}', encodeURIComponent(config.summary))

--- a/test/Share.test.js
+++ b/test/Share.test.js
@@ -108,7 +108,19 @@ describe('data normalisation', () => {
 		new Share(shareEl);
 
 		const twitterLinkElement = document.querySelector('.o-share__icon--twitter');
-		proclaim.match(twitterLinkElement.getAttribute('href'), /url=https?:\/\/localhost:[\d]+\/content\/test/);
+		const twitterHref = decodeURIComponent(twitterLinkElement.getAttribute('href'));
+
+		proclaim.match(twitterHref, /url=https?:\/\/localhost:[\d]+\/content\/test/);
+	});
+
+	it('encodes urls before sharing them', () => {
+		fixtures.insertShareComponent();
+
+		shareEl = document.querySelector('[data-o-component=o-share]');
+		new Share(shareEl);
+
+		const twitterLinkElement = document.querySelector('.o-share__icon--twitter');
+		proclaim.match(twitterLinkElement.getAttribute('href'), /url=https%3A%2F%2F/);
 	});
 });
 


### PR DESCRIPTION
This will encode the url that is passed to the social platforms.

As the url is used within the sharing url it is important to encode otherwise
if the url contains items such as a hash it will terminate the parsing
of the share url at that stage and miss anything after the hash.

eg.

`https://twitter.com/intent/tweet?url=https://www.ft.com/content/1581cbdb-c47e-3073-b629-017397a981e5#post-44945&text=Example%20Title&related=&via=FT`

When this url is parsed it will think all of this is part of the hash

`#post-44945&text=Example%20Title&related=&via=FT`