### PR TITLE
Stop using magic webpack imports

### DIFF
--- a/test/Share.test.js
+++ b/test/Share.test.js
@@ -1,16 +1,8 @@
 /* eslint-env mocha, sinon, proclaim */
 
-import proclaim from 'proclaim';
-import sinon from 'sinon/pkg/sinon';
 import * as fixtures from './helpers/fixtures';
 
-sinon.assert.expose(proclaim, {
-	includeFail: false,
-	prefix: ''
-});
-
-const Share = require('./../main');
-
+import Share from './../main';
 
 let testShare;
 let shareEl;

--- a/test/Share.test.js
+++ b/test/Share.test.js
@@ -1,4 +1,5 @@
-/* eslint-env mocha, sinon, proclaim */
+/* eslint-env mocha */
+/* global proclaim */
 
 import * as fixtures from './helpers/fixtures';
 

--- a/test/origami.test.js
+++ b/test/origami.test.js
@@ -1,9 +1,8 @@
 /* eslint-env mocha, sinon, proclaim */
-import proclaim from 'proclaim';
-import sinon from 'sinon/pkg/sinon';
+
 import * as fixtures from './helpers/fixtures';
 
-const Share = require('./../main');
+import Share from './../main';
 
 describe("Share", () => {
 	it('is defined', () => {

--- a/test/origami.test.js
+++ b/test/origami.test.js
@@ -1,4 +1,5 @@
-/* eslint-env mocha, sinon, proclaim */
+/* eslint-env mocha */
+/* global proclaim sinon */
 
 import * as fixtures from './helpers/fixtures';
 


### PR DESCRIPTION
Stop using the magic imports for proclaim and sinon and pull them from the global because that's where Karma has added them. This is required for obt v10 to be released.