### PR TITLE
Adds descriptive text to links for accessibility

### DIFF
--- a/src/js/share.js
+++ b/src/js/share.js
@@ -9,6 +9,15 @@ const socialUrls = {
 	link: "{{url}}"
 };
 
+const descriptiveLinkText = {
+	twitter: 'Share on Twitter (opens a new window)',
+	facebook: 'Share on Facebook (opens a new window)',
+	linkedin: 'Share on LinkedIn (opens a new window)',
+	pinterest: 'Share on Pinterest (opens a new window)',
+	whatsapp: 'Share on Whatsapp (opens a new window)',
+	link: 'Open link in new window'
+};
+
 /**
  * The `oShare.open` open event fires when a social network share action is
  * triggered, to open a new window.
@@ -140,9 +149,14 @@ function Share(rootEl, config) {
 			const aElement = document.createElement('a');
 
 			liElement.classList.add('o-share__action', `o-share__action--${config.links[i]}`);
+
 			spanElement.classList.add('o-share__text');
+			spanElement.innerText = descriptiveLinkText[config.links[i]];
+
 			aElement.classList.add('o-share__icon', `o-share__icon--${config.links[i]}`);
 			aElement.href = generateSocialUrl(config.links[i]);
+			aElement.setAttribute('target', '_blank');
+			aElement.setAttribute('rel', 'noopener');
 
 			aElement.appendChild(spanElement);
 			liElement.appendChild(aElement);

--- a/test/Share.test.js
+++ b/test/Share.test.js
@@ -87,6 +87,20 @@ describe('component', () => {
 		proclaim.instanceOf(document.querySelector('.o-share__icon--pinterest'), HTMLElement);
 	});
 
+	it('generates descriptive link text', () => {
+		const twitterText = document.querySelector('.o-share__icon--twitter .o-share__text').innerText;
+		const facebookText = document.querySelector('.o-share__icon--facebook .o-share__text').innerText;
+		const linkedinText = document.querySelector('.o-share__icon--linkedin .o-share__text').innerText;
+		const whatsappText = document.querySelector('.o-share__icon--whatsapp .o-share__text').innerText;
+		const pinterestText = document.querySelector('.o-share__icon--pinterest .o-share__text').innerText;
+
+		proclaim.strictEqual(twitterText, 'Share on Twitter (opens a new window)');
+		proclaim.strictEqual(facebookText, 'Share on Facebook (opens a new window)');
+		proclaim.strictEqual(linkedinText, 'Share on LinkedIn (opens a new window)');
+		proclaim.strictEqual(whatsappText, 'Share on Whatsapp (opens a new window)');
+		proclaim.strictEqual(pinterestText, 'Share on Pinterest (opens a new window)');
+	});
+
 	it('responds correctly to twitter clicks in the component', () => {
 		const twitterLinkElement = document.querySelector('.o-share__icon--twitter');
 		const event = document.createEvent('Event');


### PR DESCRIPTION
# What

Adds descriptive text to the links when the markup is not provided for the social links and therefore the component is only being used in an enhanced experience manor.

# Why 

This will improve the accessibility of this component as users of screen readers will hear what the intent of using these links will know that they open in a new window.


# Known issues 

Its worth highlighting here that this component has a "link" social option in this
component is an edge case that already behaves  in a possibly unexpected way. Clicking this option will just open the link in a new window, it doesn't do anything like copy to clipboard. For this reason this option needs its own and different descriptive text which is still not overly helpful.

# Extras

`target="_blank"` and `rel="noopener"` attributes were also added to the anchors as part of this work.