### PR TITLE
Prevents the background image from repeating

### DIFF
--- a/src/scss/share.scss
+++ b/src/scss/share.scss
@@ -40,6 +40,7 @@
 			display: block;
 			width: inherit;
 			height: inherit;
+			background-repeat: no-repeat;
 		}
 
 		// Used as an overlay to increase the hit target for accessibility


### PR DESCRIPTION
Stop the background image from repeating when the element has a larger dimension in one direction.

This has happening on FT.com articles because of some hacky css overrides.

This fix doesn't solve all the issues on FT.com but to me it does seem like a sensible property to have in place anyway and it will fix initial visual defect on ft.com

**Before**

<img width="65" alt="screen shot before the fix" src="https://user-images.githubusercontent.com/524573/78267868-5fbe2200-74ff-11ea-9553-f90ffc247ac5.png">


**After**

<img width="86" alt="Screen shot after the fix" src="https://user-images.githubusercontent.com/524573/78267907-69e02080-74ff-11ea-9db1-169f449f2bbd.png">

