### PR TITLE
Adds a location option for tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The different options are:
 * `titleExtra`: Any additional text relating to the title, e.g. site _section_.
 * `summary`: Summary text to be shared.
 * `relatedTwitterAccounts`: Comma-separated list of Twitter accounts to encourage the user to follow. See [Twitter intents](https://dev.twitter.com/docs/intents) for more info.
-* `locationOfShareComponent`: A unique identifier for the share component which is used to track shares when multiple components exist on the page.
+* `locationOfShareComponent` (optional): A unique identifier for the share component which is used to track shares when multiple components exist on the page.
 
 The different social networks are (in the order suggested by the design team):
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ The simplest markup you might need looks like this:
     data-o-share-titleExtra="{{titleExtra}}"
     data-o-share-summary="{{summary}}"
     data-o-share-relatedTwitterAccounts="{{relatedTwitterAccounts}}">
+    data-o-share-location="{{locationOfShareComponent}}"
 </div>
 ```
 
@@ -41,6 +42,7 @@ The different options are:
 * `titleExtra`: Any additional text relating to the title, e.g. site _section_.
 * `summary`: Summary text to be shared.
 * `relatedTwitterAccounts`: Comma-separated list of Twitter accounts to encourage the user to follow. See [Twitter intents](https://dev.twitter.com/docs/intents) for more info.
+* `locationOfShareComponent`: A unique identifier for the share component which is used to track shares when multiple components exist on the page.
 
 The different social networks are (in the order suggested by the design team):
 

--- a/src/js/share.js
+++ b/src/js/share.js
@@ -80,11 +80,13 @@ function Share(rootEl, config) {
 			ev.stopPropagation();
 
 			const url = actionEl.querySelector('a[href]').href;
+			const shareLocation = oShare.rootEl.dataset.oShareLocation || '';
 
 			dispatchCustomEvent('event', {
 				category: 'share',
 				action: 'click',
-				button: actionEl.textContent.trim().toLowerCase()
+				button: actionEl.textContent.trim().toLowerCase(),
+				location: shareLocation
 			}, 'oTracking');
 
 			shareSocial(url);


### PR DESCRIPTION
Adding the `data-o-share-location` option to the root element will allow
the tracking requests to include a location identifier.

This will be useful when multiple share components exist on a single
page and we want to know which is generating clicks.


<img width="689" alt="Screen shot of tracking request payload that includes location" src="https://user-images.githubusercontent.com/524573/78280425-fb0bc300-7510-11ea-9265-fd4c85844a57.png">
