### PR TITLE
Label support extra

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Form markup is allowed within the `o-share__action` label to to handle custom sh
 ```
 
 
-The `bookmark-outline` and `share` icons are made available by default for custom share features as shown in the [Origami registry demos](https://registry.origami.ft.com/components/o-share).
+The `share` icon is made available by default for custom share features as shown in the [Origami registry demos](https://registry.origami.ft.com/components/o-share).
 
 ## Sass
 

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ For example:
 ```
 
 All `$opts` options include:
-- `icons` (list) a list of social share icons to output. One or more of:
+- `icons` (list) a list of social share icons to output. One or more of the following, or any [o-icon name](https://registry.origami.ft.com/components/o-icons):
 	- `twitter`
 	- `facebook`
 	- `linkedin`
@@ -172,6 +172,24 @@ All `$opts` options include:
 	- `small` - a variant to make o-share smaller than default, i.e. `o-share--small`
 - `vertical` (boolean) - Whether to output styles for the vertical variant, i.e `o-share--vertical`
 - `inverse` (boolean) - Whether to output the inverse theme for dark backgrounds, i.e `o-share--inverse`
+
+### Colour Usecases
+
+`o-share` sets custom colour usecases for matching the colour of share buttons. These usecases are limited, for example they do not provide colours for the inverse variant, and not recommended for new projects (it is possible to output custom icons using the `oShare` mixin, without matching colours).
+
+Usecase | Property | Uses |
+---|---|---
+`o-share/default-icon` | background, border, text | Default colours, used by icons without a state (e.g. before hover).
+`o-share/ft-icon` | background, border, text | Colours to highlight FT icon social buttons like email (e.g. on hover).
+`o-share/[social-icon-name]-icon` | background, border, text | Colours to highlight social buttons with a brand, like Twitter (e.g. `o-share/twitter-icon` on hover).
+
+Use the [oColorsByUsecase mixin from o-colors](https://registry.origami.ft.com/components/o-colors/sassdoc?brand=master#function-ocolorsbyusecase) to retrieve custom colour usecases set by o-share.
+
+```scss
+.my-icon:hover {
+	background-color: oColorsByUsecase('o-share/ft-icon', 'background');
+}
+```
 
 ## JavaScript
 

--- a/demos/src/data-custom.json
+++ b/demos/src/data-custom.json
@@ -8,9 +8,6 @@
         "withTwitter": true,
         "withFacebook": true,
         "withLinkedin": true,
-        "withWhatsapp": true,
-	    "withPinterest": true,
-        "withLink": true,
-        "withMail": true
+        "withShare": true
     }
 }

--- a/demos/src/data-inverse.json
+++ b/demos/src/data-inverse.json
@@ -12,8 +12,6 @@
         "withPinterest": true,
         "withLink": true,
         "withMail": true,
-        "withShare": true,
-        "withSave": true,
         "isInverse": true
     }
 }

--- a/demos/src/data-small.json
+++ b/demos/src/data-small.json
@@ -12,8 +12,6 @@
         "withPinterest": true,
         "withLink": true,
         "withMail": true,
-        "withShare": true,
-        "withSave": true,
         "isSmall": true
     }
 }

--- a/demos/src/data-vertical.json
+++ b/demos/src/data-vertical.json
@@ -12,8 +12,6 @@
         "withMail": true,
         "withPinterest": true,
         "withLink": true,
-        "withShare": true,
-        "withSave": true,
         "isVertical": true
     }
 }

--- a/demos/src/main.mustache
+++ b/demos/src/main.mustache
@@ -49,20 +49,12 @@
 			</a>
 		</li>
 		{{/o-share.withLink}}
-		{{#o-share.withSave}}
-		<li class="o-share__action o-share__action--labelled">
-			<!-- demo only: buttons with custom JavaScript behaviour may be used for custom share features -->
-			<button class="o-share__icon o-share__icon--share">
-				<span class="o-share__text">Share</span>
-			</button>
-		</li>
-		{{/o-share.withSave}}
 		{{#o-share.withShare}}
 		<li class="o-share__action o-share__action--labelled">
 			<!-- demo only: forms with a submit button may be used for custom share features -->
 			<form method="POST" action="#">
-				<button type="submit" class="o-share__icon o-share__icon--bookmark-outline">
-					<span class="o-share__text">Save</span>
+				<button type="submit" class="o-share__icon o-share__icon--share">
+					<span class="o-share__text">Custom Share</span>
 				</button>
 			</form>
 		</li>

--- a/demos/src/pa11y.mustache
+++ b/demos/src/pa11y.mustache
@@ -73,20 +73,20 @@
 				<button class="o-share__icon o-share__icon--mail"><span class="o-share__text">Mail</span></button>
 			</li>
 			{{/o-share.withMail}}
-			{{#o-share.withSave}}
+			{{#o-share.withShare}}
 			<li class="o-share__action o-share__action--labelled">
 				<!-- demo only: buttons with custom JavaScript behaviour may be used for custom share features -->
 				<button class="o-share__icon o-share__icon--share">
 					<span class="o-share__text">Share</span>
 				</button>
 			</li>
-			{{/o-share.withSave}}
+			{{/o-share.withShare}}
 			{{#o-share.withShare}}
 			<li class="o-share__action o-share__action--labelled">
 				<!-- demo only: forms with a submit button may be used for custom share features -->
 				<form method="POST" action="#">
-					<button type="submit" class="o-share__icon o-share__icon--bookmark-outline">
-						<span class="o-share__text">Save</span>
+					<button type="submit" class="o-share__icon o-share__icon--share">
+						<span class="o-share__text">Share</span>
 					</button>
 				</form>
 			</li>

--- a/main.scss
+++ b/main.scss
@@ -69,9 +69,9 @@
 		padding: 0;
 		background-color: transparent;
 		background-repeat: no-repeat;
-		border: $o-share-border-size solid oColorsByName('black-50');
+		border: $o-share-border-size $o-share-border-style oColorsByUsecase('o-share/default-icon', 'border');
 		// undo browser default anchor tag styles
-		color: oColorsByName('black');
+		color: oColorsByUsecase('o-share/default-icon', 'text');
 		text-decoration: none;
 		// add z-index on hover or focus so the border of the icon is
 		// always displayed over the border of the next icon

--- a/origami.json
+++ b/origami.json
@@ -64,6 +64,13 @@
 			"description": "vertical"
 		},
 		{
+			"title": "Custom Share",
+			"name": "custom-share",
+			"template": "demos/src/main.mustache",
+			"data": "demos/src/data-custom.json",
+			"description": "A custom share action may also be used alongside a form or with custom JavaScript behaviour attached, as shown with the last icon in this demo. Labels may be added to describe a custom share button."
+		},
+		{
 			"title": "Pa11y",
 			"name": "pa11y",
 			"template": "demos/src/pa11y.mustache",

--- a/src/scss/_brand.scss
+++ b/src/scss/_brand.scss
@@ -16,9 +16,8 @@
 	@include oBrandDefine('o-share', 'master', (
 		'variables': (
 			'size': $o-share-icon-size,
-			'border-color': oColorsByName('black-50'),
-			'color': oColorsByName('black'),
-			'hover-color': oColorsByName('white'),
+			'border-color': oColorsByUsecase('o-share/default-icon', 'border'),
+			'color': oColorsByUsecase('o-share/default-icon', 'text'),
 			'small': (
 				'size': $o-share-icon-small-size,
 				'margin': oSpacingByName('s3'),
@@ -26,7 +25,6 @@
 			'inverse': (
 				'border-color': oColorsMix('slate', 'white', 50),
 				'color': oColorsByName('white'),
-				'hover-color': oColorsByName('white'),
 			)
 		),
 		'supports-variants': ()

--- a/src/scss/_color-use-cases.scss
+++ b/src/scss/_color-use-cases.scss
@@ -3,17 +3,26 @@
 	@include oColorsSetColor('o-share/#{$platform}', $hex);
 }
 
-// Add colour usecases for FT icon social buttons like email.
+// Add default colour usecases, used by icons without a state.
+@include oColorsSetUseCase('o-share/default-icon', (
+	'background': 'transparent',
+	'border': 'black-50',
+	'text': 'black'
+));
+
+// Add colour usecases to highlight FT icon social buttons like email.
 @include oColorsSetUseCase('o-share/ft-icon', (
 	'background': 'teal-40',
 	'border': 'teal-40',
+	'text': 'white'
 ));
 
-// Add colour usecases for social buttons like Twitter.
+// Add colour usecases to highlight social buttons with a brand, like Twitter.
 @each $platform, $hex in $_o-share-colors {
 	@include oColorsSetUseCase('o-share/#{$platform}-icon', (
 		'background': 'o-share/#{$platform}',
 		'border': 'o-share/#{$platform}',
+		'text': 'white'
 	));
 }
 

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -6,8 +6,6 @@
 	$border-color: _oShareGet('border-color', $name);
 	$color: _oShareGet('color', $name);
 	$color-encoded: str-slice(ie-hex-str($color), 4);
-	$hover-color: _oShareGet('hover-color', $name);
-	$hover-color-encoded: str-slice(ie-hex-str($hover-color), 4);
 
 	.o-share__icon {
 		color: $color;
@@ -36,9 +34,9 @@
 			$usecase: if($is-ft-icon, 'o-share/ft-icon', 'o-share/#{$icon-name}-icon');
 			border-color: oColorsByUsecase($usecase, 'border');
 			background-color: oColorsByUsecase($usecase, 'background');
-			color: $hover-color;
+			color: oColorsByUsecase($usecase, 'text');
 			&:before {
-				background-image: url($service-url + $query + "&format=svg&tint=#{$hover-color-encoded}");
+				background-image: url($service-url + $query + "&format=svg&tint=#{oColorsByUsecase($usecase, 'text')}");
 			}
 		}
 

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -29,11 +29,11 @@ $o-share-ft-icons-version: "1" !default;
 
 // Icon names that will use fticons instead of ftsocial
 /// @type Map
-$o-share-ft-icons-names: (mail, link, share, bookmark-outline);
+$o-share-ft-icons-names: (mail, link, share);
 
 /// List of accepted social network icons, and the version
 /// @type Map
-$_o-share-icons: (twitter, facebook, linkedin, link, share, mail, pinterest, whatsapp, bookmark-outline);
+$_o-share-icons: (twitter, facebook, linkedin, link, share, mail, pinterest, whatsapp);
 
 /// A map of icons to their colour.
 /// @type Map

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -14,6 +14,10 @@ $o-share-icon-small-size: 28px !default;
 /// @type Number
 $o-share-border-size: 1px !default;
 
+/// Border style
+/// @type Number
+$o-share-border-style: solid !default;
+
 /// Option to change the base of the image service url
 ///
 /// @type String


### PR DESCRIPTION
**Remove `bookmark-outline` (before release)**
The share button on ft.com is currently a n-myft-ui button with
extra styles and behaviour attached, so no one will be using
`bookmark-outline`.

**Add new custom colour usecases.**
This will let users like next-article match o-share colours
more accurately to override n-myft-ui save icon colours 😷
Financial-Times/next-article#3796

**Add `$o-share-border-style` variable**
So next-article can more accurately override the n-myft-ui save icon
to match o-share 😷
https://github.com/Financial-Times/next-article/pull/3796/files