### PR TITLE
CI-183 Add title to the social descriptive link text

### DIFF
--- a/src/js/share.js
+++ b/src/js/share.js
@@ -10,11 +10,11 @@ const socialUrls = {
 };
 
 const descriptiveLinkText = {
-	twitter: 'Share on Twitter (opens a new window)',
-	facebook: 'Share on Facebook (opens a new window)',
-	linkedin: 'Share on LinkedIn (opens a new window)',
-	pinterest: 'Share on Pinterest (opens a new window)',
-	whatsapp: 'Share on Whatsapp (opens a new window)',
+	twitter: 'Share {{title}} on Twitter (opens a new window)',
+	facebook: 'Share {{title}} on Facebook (opens a new window)',
+	linkedin: 'Share {{title}} on LinkedIn (opens a new window)',
+	pinterest: 'Share {{title}} on Pinterest (opens a new window)',
+	whatsapp: 'Share {{title}} on Whatsapp (opens a new window)',
 	link: 'Open link in new window'
 };
 
@@ -136,6 +136,19 @@ function Share(rootEl, config) {
 	}
 
 	/**
+	  * Transforms the descriptive text for social links
+	  *
+	  * @private
+	  * @param {string} socialNetwork - Name of the social network that we support (e.g. twitter, facebook, linkedin, pinterest)
+	  * @returns {string}
+	  */
+	function generateDesriptiveLinkText (socialNetwork) {
+		let templateLinkText = descriptiveLinkText[socialNetwork];
+		templateLinkText = templateLinkText.replace('{{title}}', config.title);
+		return templateLinkText;
+	}
+
+	/**
 	  * Renders the list of social networks in {@link config.links}
 	  *
 	  * @returns {undefined}
@@ -153,7 +166,7 @@ function Share(rootEl, config) {
 			liElement.classList.add('o-share__action', `o-share__action--${config.links[i]}`);
 
 			spanElement.classList.add('o-share__text');
-			spanElement.innerText = descriptiveLinkText[config.links[i]];
+			spanElement.innerText = generateDesriptiveLinkText(config.links[i]);
 
 			aElement.classList.add('o-share__icon', `o-share__icon--${config.links[i]}`);
 			aElement.href = generateSocialUrl(config.links[i]);

--- a/test/Share.test.js
+++ b/test/Share.test.js
@@ -93,11 +93,11 @@ describe('component', () => {
 		const whatsappText = document.querySelector('.o-share__icon--whatsapp .o-share__text').innerText;
 		const pinterestText = document.querySelector('.o-share__icon--pinterest .o-share__text').innerText;
 
-		proclaim.strictEqual(twitterText, 'Share on Twitter (opens a new window)');
-		proclaim.strictEqual(facebookText, 'Share on Facebook (opens a new window)');
-		proclaim.strictEqual(linkedinText, 'Share on LinkedIn (opens a new window)');
-		proclaim.strictEqual(whatsappText, 'Share on Whatsapp (opens a new window)');
-		proclaim.strictEqual(pinterestText, 'Share on Pinterest (opens a new window)');
+		proclaim.strictEqual(twitterText, 'Share Test Article on Twitter (opens a new window)');
+		proclaim.strictEqual(facebookText, 'Share Test Article on Facebook (opens a new window)');
+		proclaim.strictEqual(linkedinText, 'Share Test Article on LinkedIn (opens a new window)');
+		proclaim.strictEqual(whatsappText, 'Share Test Article on Whatsapp (opens a new window)');
+		proclaim.strictEqual(pinterestText, 'Share Test Article on Pinterest (opens a new window)');
 	});
 
 	it('responds correctly to twitter clicks in the component', () => {


### PR DESCRIPTION
Through the DAC audit, we learned that the share components on the home
page do not have descriptive enough link text. DAC recommends adding
the title of the video to the link text. The share components are used
on a few apps (e.g. `next-article`) so I thought it might make more
sense to update the descriptive link text in `o-share` rather than in
each individual app.

Please let me know if you think this is appropriate! I tested it using 
`next-front-page` and it looks like the changes work:

![image](https://user-images.githubusercontent.com/30316203/86109146-f4fb9300-babb-11ea-8b0d-307ca08a6055.png)

[DAC ticket](https://financialtimes.atlassian.net/secure/RapidBoard.jspa?rapidView=1153&projectKey=CI&modal=detail&selectedIssue=CI-183)