### PR TITLE
Use the new $default-branch macro instead of hardcoding the branch name

### DIFF
--- a/.github/workflows/percy.yml
+++ b/.github/workflows/percy.yml
@@ -7,7 +7,7 @@ on:
       - reopened
       - synchronize
   push:
-    branches: master
+    branches: $default-branch
 jobs:
   percy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This will help with any future wok on renaming the default branch name.