### PR TITLE
add extension to relative imports to make the code work directly in a browser

### DIFF
--- a/demos/src/demo.js
+++ b/demos/src/demo.js
@@ -1,4 +1,4 @@
-import Share from '../../main';
+import Share from '../../main.js';
 window.oShare = Share;
 
 document.addEventListener('DOMContentLoaded', function() {

--- a/main.js
+++ b/main.js
@@ -1,4 +1,4 @@
-import Share from './src/js/share';
+import Share from './src/js/share.js';
 
 const constructAll = function() {
 	Share.init();

--- a/test/Share.test.js
+++ b/test/Share.test.js
@@ -1,8 +1,8 @@
 /* eslint-env mocha */
 /* global proclaim */
 
-import * as fixtures from './helpers/fixtures';
-import Share from './../main';
+import * as fixtures from './helpers/fixtures.js';
+import Share from './../main.js';
 
 let testShare;
 let shareEl;

--- a/test/origami.test.js
+++ b/test/origami.test.js
@@ -1,8 +1,8 @@
 /* eslint-env mocha */
 /* global proclaim sinon */
 
-import * as fixtures from './helpers/fixtures';
-import Share from './../main';
+import * as fixtures from './helpers/fixtures.js';
+import Share from './../main.js';
 
 describe("Share", () => {
 	it('is defined', () => {


### PR DESCRIPTION
relative imports require the full path including the extension because browsers use the import name to make a network request and they do not implicitly add a .js file extension if one is missing