### PR TITLE
State o-share supports masteer and internal brands 

### DIFF
--- a/origami.json
+++ b/origami.json
@@ -1,6 +1,10 @@
 {
 	"description": "Provides styling for social media sharing links",
 	"keywords": [ "share", "link", "social", "facebook", "twitter", "linkedin", "whatsapp", "email" ],
+	"brands" : [
+		"master",
+		"internal"
+	],
 	"origamiType": "module",
 	"origamiCategory": "components",
 	"origamiVersion": 1,

--- a/src/scss/_brand.scss
+++ b/src/scss/_brand.scss
@@ -30,3 +30,22 @@
 		'supports-variants': ()
 	));
 }
+
+@if oBrandGetCurrentBrand() == 'internal' {
+	@include oBrandDefine('o-share', 'internal', (
+		'variables': (
+			'size': $o-share-icon-size,
+			'border-color': oColorsByUsecase('o-share/default-icon', 'border'),
+			'color': oColorsByUsecase('o-share/default-icon', 'text'),
+			'small': (
+				'size': $o-share-icon-small-size,
+				'margin': oSpacingByName('s3'),
+			),
+			'inverse': (
+				'border-color': oColorsMix('slate', 'white', 50),
+				'color': oColorsByName('white'),
+			)
+		),
+		'supports-variants': ()
+	));
+}


### PR DESCRIPTION
We need to state explicitly the brands which are supported because the default supported brands if no `brands` field is supplied is `master`.

This change will allow internal branded products such as the new wordpress theme to use o-share