### PR TITLE
Make the new corporate icon from fticons available in o-share

### DIFF
--- a/demos/src/data-custom.json
+++ b/demos/src/data-custom.json
@@ -8,6 +8,7 @@
         "withTwitter": true,
         "withFacebook": true,
         "withLinkedin": true,
+        "withEnterpriseSharing": true,
         "withShare": true
     }
 }

--- a/demos/src/data-custom.json
+++ b/demos/src/data-custom.json
@@ -8,7 +8,7 @@
         "withTwitter": true,
         "withFacebook": true,
         "withLinkedin": true,
-        "withEnterpriseSharing": true,
+        "withEnterpriseSharing": false,
         "withShare": true
     }
 }

--- a/demos/src/data-inverse.json
+++ b/demos/src/data-inverse.json
@@ -10,7 +10,7 @@
         "withLinkedin": true,
         "withWhatsapp": true,
         "withPinterest": true,
-        "withEnterpriseSharing": true,
+        "withEnterpriseSharing": false,
         "withShare": true,
         "withLink": true,
         "withMail": true,

--- a/demos/src/data-inverse.json
+++ b/demos/src/data-inverse.json
@@ -11,7 +11,7 @@
         "withWhatsapp": true,
         "withPinterest": true,
         "withEnterpriseSharing": false,
-        "withShare": true,
+        "withShare": false,
         "withLink": true,
         "withMail": true,
         "isInverse": true

--- a/demos/src/data-inverse.json
+++ b/demos/src/data-inverse.json
@@ -10,6 +10,8 @@
         "withLinkedin": true,
         "withWhatsapp": true,
         "withPinterest": true,
+        "withEnterpriseSharing": true,
+        "withShare": true,
         "withLink": true,
         "withMail": true,
         "isInverse": true

--- a/demos/src/data-small.json
+++ b/demos/src/data-small.json
@@ -10,7 +10,7 @@
         "withLinkedin": true,
         "withWhatsapp": true,
         "withPinterest": true,
-        "withEnterpriseSharing": true,
+        "withEnterpriseSharing": false,
         "withShare": true,
         "withLink": true,
         "withMail": true,

--- a/demos/src/data-small.json
+++ b/demos/src/data-small.json
@@ -11,7 +11,7 @@
         "withWhatsapp": true,
         "withPinterest": true,
         "withEnterpriseSharing": false,
-        "withShare": true,
+        "withShare": false,
         "withLink": true,
         "withMail": true,
         "isSmall": true

--- a/demos/src/data-small.json
+++ b/demos/src/data-small.json
@@ -10,6 +10,8 @@
         "withLinkedin": true,
         "withWhatsapp": true,
         "withPinterest": true,
+        "withEnterpriseSharing": true,
+        "withShare": true,
         "withLink": true,
         "withMail": true,
         "isSmall": true

--- a/demos/src/data-vertical.json
+++ b/demos/src/data-vertical.json
@@ -12,7 +12,7 @@
         "withMail": true,
         "withPinterest": true,
         "withEnterpriseSharing": false,
-        "withShare": true,
+        "withShare": false,
         "withLink": true,
         "isVertical": true
     }

--- a/demos/src/data-vertical.json
+++ b/demos/src/data-vertical.json
@@ -11,7 +11,7 @@
         "withWhatsapp": true,
         "withMail": true,
         "withPinterest": true,
-        "withEnterpriseSharing": true,
+        "withEnterpriseSharing": false,
         "withShare": true,
         "withLink": true,
         "isVertical": true

--- a/demos/src/data-vertical.json
+++ b/demos/src/data-vertical.json
@@ -1,6 +1,6 @@
 {
     "o-share": {
-    	"url": "http://on.ft.com/1mUdgA2",
+        "url": "http://on.ft.com/1mUdgA2",
         "title": "Pfizer+says+its+AstraZeneca+vow+over+big+UK+presence+is+binding",
         "titleExtra": "FT%2Ecom+%7C+Pharmaceuticals",
         "summary": "US+drugs+group+vows+to+maintain+big+British+presence",
@@ -11,6 +11,8 @@
         "withWhatsapp": true,
         "withMail": true,
         "withPinterest": true,
+        "withEnterpriseSharing": true,
+        "withShare": true,
         "withLink": true,
         "isVertical": true
     }

--- a/demos/src/data.json
+++ b/demos/src/data.json
@@ -11,7 +11,7 @@
         "withWhatsapp": true,
         "withPinterest": true,
         "withEnterpriseSharing": false,
-        "withShare": true,
+        "withShare": false,
         "withLink": true,
         "withMail": true
     }

--- a/demos/src/data.json
+++ b/demos/src/data.json
@@ -10,7 +10,7 @@
         "withLinkedin": true,
         "withWhatsapp": true,
         "withPinterest": true,
-        "withEnterpriseSharing": true,
+        "withEnterpriseSharing": false,
         "withShare": true,
         "withLink": true,
         "withMail": true

--- a/demos/src/data.json
+++ b/demos/src/data.json
@@ -9,7 +9,9 @@
         "withFacebook": true,
         "withLinkedin": true,
         "withWhatsapp": true,
-	    "withPinterest": true,
+        "withPinterest": true,
+        "withEnterpriseSharing": true,
+        "withShare": true,
         "withLink": true,
         "withMail": true
     }

--- a/demos/src/main.mustache
+++ b/demos/src/main.mustache
@@ -35,6 +35,13 @@
 			</a>
 		</li>
 		{{/o-share.withPinterest}}
+		{{#o-share.withEnterpriseSharing}}
+		<li class="o-share__action o-share__action--labelled">
+			<a class="o-share__icon o-share__icon--corporate" href="http://example.com/?url={{o-share.url}}&amp;description={{o-share.title}}" rel="noopener">
+				<span class="o-share__text">Org Share</span>
+			</a>
+		</li>
+		{{/o-share.withEnterpriseSharing}}
 		{{#o-share.withMail}}
 		<li class="o-share__action">
 			<button class="o-share__icon o-share__icon--mail">
@@ -54,7 +61,7 @@
 			<!-- demo only: forms with a submit button may be used for custom share features -->
 			<form method="POST" action="#">
 				<button type="submit" class="o-share__icon o-share__icon--share">
-					<span class="o-share__text">Custom Share</span>
+					<span class="o-share__text">Share</span>
 				</button>
 			</form>
 		</li>

--- a/demos/src/pa11y.mustache
+++ b/demos/src/pa11y.mustache
@@ -89,14 +89,6 @@
 			{{/o-share.withMail}}
 			{{#o-share.withShare}}
 			<li class="o-share__action o-share__action--labelled">
-				<!-- demo only: buttons with custom JavaScript behaviour may be used for custom share features -->
-				<button class="o-share__icon o-share__icon--share">
-					<span class="o-share__text">Share</span>
-				</button>
-			</li>
-			{{/o-share.withShare}}
-			{{#o-share.withShare}}
-			<li class="o-share__action o-share__action--labelled">
 				<!-- demo only: forms with a submit button may be used for custom share features -->
 				<form method="POST" action="#">
 					<button type="submit" class="o-share__icon o-share__icon--share">

--- a/demos/src/pa11y.mustache
+++ b/demos/src/pa11y.mustache
@@ -26,6 +26,13 @@
 				<a class="o-share__icon o-share__icon--pinterest" href="http://www.pinterest.com/pin/create/button/?url={{o-share.url}}&amp;description={{o-share.title}}" rel="noopener"><span class="o-share__text">Pinterest</span></a>
 			</li>
 			{{/o-share.withPinterest}}
+			{{#o-share.withEnterpriseSharing}}
+			<li class="o-share__action o-share__action--labelled">
+				<a class="o-share__icon o-share__icon--corporate" href="http://example.com/?url={{o-share.url}}&amp;description={{o-share.title}}" rel="noopener">
+					<span class="o-share__text">Org Share</span>
+				</a>
+			</li>
+			{{/o-share.withEnterpriseSharing}}
 			{{#o-share.withMail}}
 			<li class="o-share__action">
 				<button class="o-share__icon o-share__icon--mail"><span class="o-share__text">Mail</span></button>
@@ -68,6 +75,13 @@
 				<a class="o-share__icon o-share__icon--pinterest" href="http://www.pinterest.com/pin/create/button/?url={{o-share.url}}&amp;description={{o-share.title}}" rel="noopener"><span class="o-share__text">Pinterest</span></a>
 			</li>
 			{{/o-share.withPinterest}}
+			{{#o-share.withEnterpriseSharing}}
+			<li class="o-share__action o-share__action--labelled">
+				<a class="o-share__icon o-share__icon--corporate" href="http://example.com/?url={{o-share.url}}&amp;description={{o-share.title}}" rel="noopener">
+					<span class="o-share__text">Org Share</span>
+				</a>
+			</li>
+			{{/o-share.withEnterpriseSharing}}
 			{{#o-share.withMail}}
 			<li class="o-share__action">
 				<button class="o-share__icon o-share__icon--mail"><span class="o-share__text">Mail</span></button>

--- a/main.scss
+++ b/main.scss
@@ -13,13 +13,13 @@
 /// Output all o-share styles.
 ///
 /// @access public
-/// @param {Map} $opts [('icons': ('twitter', 'facebook', 'linkedin', 'link', 'share', 'mail', 'pinterest', 'whatsapp'), 'sizes': ('small'), 'vertical': true, 'inverse': true)] The o-share variants to include styles for (see the README for more details).
+/// @param {Map} $opts [('icons': ('twitter', 'facebook', 'linkedin', 'link', 'share', 'mail', 'pinterest', 'whatsapp', 'corporate'), 'sizes': ('small'), 'vertical': true, 'inverse': true)] The o-share variants to include styles for (see the README for more details).
 /// @example Output all styles.
 ///		@include oShare();
 ///
 /// @example Output styles for select variants.
 ///		@include oShare($opts: (
-///       'icons': ('twitter', 'facebook', 'linkedin', 'link', 'share', 'mail', 'pinterest', 'whatsapp'),
+///       'icons': ('twitter', 'facebook', 'linkedin', 'link', 'share', 'mail', 'pinterest', 'whatsapp', 'corporate'),
 ///       'sizes': ('small'),
 ///       'vertical': true,
 ///       'inverse': true

--- a/main.scss
+++ b/main.scss
@@ -102,6 +102,7 @@
 
 	.o-share__text {
 		@include oTypographySans($scale: -1);
+		text-align: center;
 	}
 
 	// Icon text is visually hidden by default without the class

--- a/origami.json
+++ b/origami.json
@@ -1,6 +1,6 @@
 {
 	"description": "Provides styling for social media sharing links",
-	"keywords": [ "share", "link", "social", "facebook", "twitter", "linkedin", "whatsapp", "email" ],
+	"keywords": [ "share", "link", "social", "facebook", "twitter", "linkedin", "whatsapp", "email", "corporate" ],
 	"brands" : [
 		"master",
 		"internal"

--- a/src/js/share.js
+++ b/src/js/share.js
@@ -6,7 +6,8 @@ const socialUrls = {
 	linkedin: "http://www.linkedin.com/shareArticle?mini=true&url={{url}}&title={{title}}+%7C+{{titleExtra}}&summary={{summary}}&source=Financial+Times",
 	pinterest: "http://www.pinterest.com/pin/create/button/?url={{url}}&description={{title}}",
 	whatsapp: "whatsapp://send?text={{title}}%20({{titleExtra}})%20-%20{{url}}",
-	link: "{{url}}"
+	link: "{{url}}",
+	enterpriseSharing: "{{url}}",
 };
 
 const descriptiveLinkText = {
@@ -15,7 +16,8 @@ const descriptiveLinkText = {
 	linkedin: 'Share {{title}} on LinkedIn (opens a new window)',
 	pinterest: 'Share {{title}} on Pinterest (opens a new window)',
 	whatsapp: 'Share {{title}} on Whatsapp (opens a new window)',
-	link: 'Open link in new window'
+	link: 'Open link in new window',
+	enterpriseSharing: 'Share {{title}} with your Enterprise Sharing tools (opens a new window)',
 };
 
 /**

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -33,11 +33,11 @@ $o-share-ft-icons-version: "1" !default;
 
 // Icon names that will use fticons instead of ftsocial
 /// @type Map
-$o-share-ft-icons-names: (mail, link, share);
+$o-share-ft-icons-names: (corporate, mail, link, share);
 
 /// List of accepted social network icons, and the version
 /// @type Map
-$_o-share-icons: (twitter, facebook, linkedin, link, share, mail, pinterest, whatsapp);
+$_o-share-icons: (twitter, facebook, linkedin, link, share, mail, pinterest, whatsapp, corporate);
 
 /// A map of icons to their colour.
 /// @type Map


### PR DESCRIPTION
We have a new sharing platform, the new enterprise super gift product. This pull request adds the corporate icon into o-share to be used for this new sharing product.

Here is the link to the design for this -- https://www.figma.com/proto/Tun2MN4GA77UeUQUUXvXas/Super-Gifting---Main-File?node-id=552%3A1314&scaling=min-zoom

Here is a screenshot of the new share button/link in the list
![image](https://user-images.githubusercontent.com/1569131/109499586-0521a300-7a8d-11eb-8b9e-e0f0d842f368.png)

Here is a screenshot showing the hover/focus states of the share buttons/links
![image](https://user-images.githubusercontent.com/1569131/109499779-3f8b4000-7a8d-11eb-9a5f-0d6d19c80e10.png)
